### PR TITLE
Legacy header placeholder added for CSP.

### DIFF
--- a/texts/HEADER/_RESULTS/CSP_LEGACY_HEADER_SET/de.wiki
+++ b/texts/HEADER/_RESULTS/CSP_LEGACY_HEADER_SET/de.wiki
@@ -1,1 +1,1 @@
-Der veraltete Header `X-Content-Security-Policy` ist gesetzt. Der neue standardisierte Header ist `Content-Security-Policy`.
+Der veraltete Header <i>:HEADER_NAME</i> ist gesetzt. Der neue standardisierte Header ist <i>Content-Security-Policy</i>.

--- a/texts/HEADER/_RESULTS/CSP_LEGACY_HEADER_SET/en.wiki
+++ b/texts/HEADER/_RESULTS/CSP_LEGACY_HEADER_SET/en.wiki
@@ -1,1 +1,1 @@
-The outdated header 'X-Content-Security-Policy' is used. The new standardized header is 'Content-Security-Policy'.
+The outdated header <i>:HEADER_NAME</i> is used. The new standardized header is <i>Content-Security-Policy</i>.


### PR DESCRIPTION
Vielleicht sollten wir auch gleich bei der Gelegenheit die backticks ersetzen?